### PR TITLE
refactor: rename apy-id to apyId and apy-source to apySource

### DIFF
--- a/archive/descriptions/strategies/1.json
+++ b/archive/descriptions/strategies/1.json
@@ -4,8 +4,8 @@
     "asset": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     "name": "Compound",
     "description": "**Lending** - This vault uses a lending strategy on CompoundV2 using the DAI market. Which generates compound interest on your DAI by lending it out to borrowers.",
-    "apy-id": "cc110152-36c2-4e10-9c12-c5b4eb662143",
-    "apy-source": "defillama",
+    "apyId": "cc110152-36c2-4e10-9c12-c5b4eb662143",
+    "apySource": "defillama",
     "resolver": "compoundV2"
   },
   "0xB98B71F5B756493a898E8B05ac7d6B20644435E6": {
@@ -13,8 +13,8 @@
     "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "name": "Compound",
     "description": "**Lending** - This vault uses a lending strategy on CompoundV2 using the USDC market. Which generates compound interest on your USDC by lending it out to borrowers.",
-    "apy-id": "cefa9bb8-c230-459a-a855-3b94e96acd8c",
-    "apy-source": "defillama",
+    "apyId": "cefa9bb8-c230-459a-a855-3b94e96acd8c",
+    "apySource": "defillama",
     "resolver": "compoundV2"
   },
   "0x7a2F96F36a03c91Cbf5f4490B4002254c5b7a5E8": {
@@ -22,8 +22,8 @@
     "asset": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     "name": "Yearn",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Yearn to maximize yield generation, leveraging Yearn's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "7be3388a-0591-4281-a6f3-eff3217693fa",
-    "apy-source": "defillama",
+    "apyId": "7be3388a-0591-4281-a6f3-eff3217693fa",
+    "apySource": "defillama",
     "resolver": "yearn"
   },
   "0x104AeAC31048aD01A2836254ad0330F3fC8E7Fbc": {
@@ -31,8 +31,8 @@
     "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "name": "Yearn",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Yearn to maximize yield generation, leveraging Yearn's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "72124487-ba91-46d8-907e-31b8eca90af3",
-    "apy-source": "defillama",
+    "apyId": "72124487-ba91-46d8-907e-31b8eca90af3",
+    "apySource": "defillama",
     "resolver": "yearn"
   },
   "0x743EaD6E224283D00e29866327d4E35B6f196F79": {
@@ -40,8 +40,8 @@
     "asset": "0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86",
     "name": "Origin",
     "description": "**OETH** - OETH integrates with various Liquid Staking Provider to optimize interest earned by staking Ether.\n      ----\n      The OETH protocol also utilizes Curve and Convex Finance to earn trading fees and additional rewards on ETH / OETH. It automatically claims and converts bonus incentives that are being distributed by these protocols.",
-    "apy-id": "529258ee-9b27-4fcf-a32c-b82abb3fda68",
-    "apy-source": "defillama",
+    "apyId": "529258ee-9b27-4fcf-a32c-b82abb3fda68",
+    "apySource": "defillama",
     "resolver": "origin"
   },
   "0xB597852043Ce22D293F533143C2bE47aF94C456A": {
@@ -49,8 +49,8 @@
     "asset": "0xc4AD29ba4B3c580e6D59105FFf484999997675Ff",
     "name": "Yearn",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Yearn to maximize yield generation, leveraging Yearn's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "faffa839-9797-404b-89c1-475b81e4afb0",
-    "apy-source": "defillama",
+    "apyId": "faffa839-9797-404b-89c1-475b81e4afb0",
+    "apySource": "defillama",
     "resolver": "yearn"
   },
   "0x33d9A49CfB1005E722a3BEE2959b2Ed3c127eA84": {
@@ -58,8 +58,8 @@
     "asset": "0xFCc5c47bE19d06BF83eB04298b026F81069ff65b",
     "name": "Yearn",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Yearn to maximize yield generation, leveraging Yearn's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "320550a3-b7c4-4017-a5dd-f3ebed459470",
-    "apy-source": "defillama",
+    "apyId": "320550a3-b7c4-4017-a5dd-f3ebed459470",
+    "apySource": "defillama",
     "resolver": "yearn"
   },
   "0x99513f12ac1dd0d9979e07e59b06Cd5d6dfB9330": {
@@ -67,8 +67,8 @@
     "asset": "0x21E27a5E5513D6e65C4f830167390997aA84843a",
     "name": "Yearn",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Yearn to maximize yield generation, leveraging Yearn's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "a2225954-96ac-4905-be19-4d47ebeeb878",
-    "apy-source": "defillama",
+    "apyId": "a2225954-96ac-4905-be19-4d47ebeeb878",
+    "apySource": "defillama",
     "resolver": "yearn"
   },
   "0xF35Dc1F592ed2D6dE8a9af2116683f2D6fac2a7f": {
@@ -76,8 +76,8 @@
     "asset": "0x5271045F7B73c17825A7A7aee6917eE46b0B7520",
     "name": "Yearn",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Yearn to maximize yield generation, leveraging Yearn's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "4f000353-5bb0-4e8c-ad03-194f0662680d",
-    "apy-source": "defillama",
+    "apyId": "4f000353-5bb0-4e8c-ad03-194f0662680d",
+    "apySource": "defillama",
     "resolver": "yearn"
   },
   "0x9bdC69Aaba05E1425a44fc439a7Fe92615977a1f": {
@@ -85,8 +85,8 @@
     "asset": "0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490",
     "name": "Yearn",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Yearn to maximize yield generation, leveraging Yearn's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "4f000353-5bb0-4e8c-ad03-194f0662680d",
-    "apy-source": "defillama",
+    "apyId": "4f000353-5bb0-4e8c-ad03-194f0662680d",
+    "apySource": "defillama",
     "resolver": "yearn"
   },
   "0x1125f17E999ea4F2498D01c35785fE90B5C4d8ff": {
@@ -94,8 +94,8 @@
     "asset": "0xdf0770dF86a8034b3EFEf0A1Bb3c889B8332FF56",
     "name": "Stargate",
     "description": "**Stargate Bridge LP-Compounding** - This vault earns compounding interest on LP-tokens of the USDC bridge liquidity pool on Stargate. The LP-tokens are staked in a gauge on Stargate to earn governance tokens. The rewards are then sold for additional LP tokens which get redeposited into the strategy.",
-    "apy-id": "c24d9138-51aa-48f4-a445-7f33bf7bf5fb",
-    "apy-source": "defillama",
+    "apyId": "c24d9138-51aa-48f4-a445-7f33bf7bf5fb",
+    "apySource": "defillama",
     "resolver": "stargate"
   },
   "0xC09C94BDb26cAEd2099C7ffA8fBAc903E9338D02": {
@@ -104,8 +104,8 @@
     "name": "Idle",
     "description": "**Senior Tranche** - The vault supplies assets into a senior tranche of Idle. Senior tranches offer stable returns with built-in coverage but reduced upside.",
     "resolver": "idleSenior",
-    "apy-id": "7368c365-8280-4f4c-99dd-d7a989b31176",
-    "apy-source": "defillama"
+    "apyId": "7368c365-8280-4f4c-99dd-d7a989b31176",
+    "apySource": "defillama"
   },
   "0x197F58De2559097d956b4192e8F89A2F36190a48": {
     "address": "0x197F58De2559097d956b4192e8F89A2F36190a48",
@@ -113,16 +113,16 @@
     "name": "Idle",
     "description": "**Junior Tranche** - The vault supplies assets into a junior tranche of Idle. Junior tranches offer higher returns but with higher risk since they minize the risk of the corresponding.",
     "resolver": "idleJunior",
-    "apy-id": "4419943a-dc35-470c-8210-a6f087e1fb70",
-    "apy-source": "defillama"
+    "apyId": "4419943a-dc35-470c-8210-a6f087e1fb70",
+    "apySource": "defillama"
   },
   "0xaD8c7EbEEA0706476CB6656349456B44ccd79A64": {
     "address": "0xaD8c7EbEEA0706476CB6656349456B44ccd79A64",
     "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "name": "Idle",
     "description": "**Senior Tranche** - The vault supplies assets into a senior tranche of Idle. Senior tranches offer stable returns with built-in coverage but reduced upside.",
-    "apy-id": "527abdc2-bffe-4114-be35-9e45bbe57618",
-    "apy-source": "defillama",
+    "apyId": "527abdc2-bffe-4114-be35-9e45bbe57618",
+    "apySource": "defillama",
     "resolver": "idleSenior"
   },
   "0x29bE2A691394f635a9AC506a238Cc201BAA52351": {
@@ -131,8 +131,8 @@
     "name": "Idle",
     "description": "**Junior Tranche** - The vault supplies assets into a junior tranche of Idle. Junior tranches offer higher returns but with higher risk since they minize the risk of the corresponding.",
     "resolver": "idleJunior",
-    "apy-id": "3cc9c2ca-40e6-48e1-ab59-56812f05343f",
-    "apy-source": "defillama"
+    "apyId": "3cc9c2ca-40e6-48e1-ab59-56812f05343f",
+    "apySource": "defillama"
   },
   "0xE48d33e869f874D6BEe3701beF22ae72c60A3b3c": {
     "address": "0xE48d33e869f874D6BEe3701beF22ae72c60A3b3c",
@@ -140,16 +140,16 @@
     "name": "Idle",
     "description": "**Junior Tranche** - The vault supplies assets into a junior tranche of Idle. Junior tranches offer higher returns but with higher risk since they minize the risk of the corresponding.",
     "resolver": "idleJunior",
-    "apy-id": "9f69b48a-def9-4d55-86eb-10e9deaa6008",
-    "apy-source": "defillama"
+    "apyId": "9f69b48a-def9-4d55-86eb-10e9deaa6008",
+    "apySource": "defillama"
   },
   "0x550DE5484998957F90986FfAfcE505E790A43CDA": {
     "address": "0x550DE5484998957F90986FfAfcE505E790A43CDA",
     "asset": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
     "name": "Idle",
     "description": "**Senior Tranche** - The vault supplies assets into a senior tranche of Idle. Senior tranches offer stable returns with built-in coverage but reduced upside.",
-    "apy-id": "61f8ea49-8293-49f4-a959-84b0ef8872b5",
-    "apy-source": "defillama",
+    "apyId": "61f8ea49-8293-49f4-a959-84b0ef8872b5",
+    "apySource": "defillama",
     "resolver": "idleSenior"
   },
   "0x2661495A1B6BF8b7a2F33c707A74801aBeCA3d74": {
@@ -157,8 +157,8 @@
     "asset": "0x856c4Efb76C1D1AE02e20CEB03A2A6a08b0b8dC3",
     "name": "Origin",
     "description": "**OUSD** - OUSD integrates with Aave and Compound to automate yield on over-collateralized loans.\n    ----\n    The OUSD protocol also routes USDT, USDC, and DAI to highly-performing liquidity pools as determined by trading volume and rewards tokens (e.g. Curve rewards CRV tokens to liquidity providers). Yields are then passed on to OUSD holders.\n    ---\n    In addition to collecting interest from and fees from market making, the protocol automatically claims and converts bonus incentives that are being distributed by DeFi protocols.",
-    "apy-id": "423681e3-4787-40ce-ae43-e9f67c5269b3",
-    "apy-source": "defillama",
+    "apyId": "423681e3-4787-40ce-ae43-e9f67c5269b3",
+    "apySource": "defillama",
     "resolver": "origin"
   },
   "0x239377821bbA921307622349C20ffb3DbBD36F2D": {
@@ -166,8 +166,8 @@
     "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "name": "Idle",
     "description": "**Junior Tranche** - The vault supplies assets into a junior tranche of Idle. Junior tranches offer higher returns but with higher risk since they minize the risk of the corresponding.",
-    "apy-id": "25c15bbd-6287-4740-aca8-ff516327f5f3",
-    "apy-source": "defillama",
+    "apyId": "25c15bbd-6287-4740-aca8-ff516327f5f3",
+    "apySource": "defillama",
     "resolver": "idleJunior"
   },
   "0xbA1d38D6bb5E2FA2a08aA9f660B2c7A6D933Da87": {
@@ -175,8 +175,8 @@
     "asset": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     "name": "Idle",
     "description": "**Junior Tranche** - The vault supplies assets into a junior tranche of Idle. Junior tranches offer higher returns but with higher risk since they minize the risk of the corresponding.",
-    "apy-id": "4419943a-dc35-470c-8210-a6f087e1fb70",
-    "apy-source": "defillama",
+    "apyId": "4419943a-dc35-470c-8210-a6f087e1fb70",
+    "apySource": "defillama",
     "resolver": "idleJunior"
   },
   "0xA301B31184CF084e817C6eB1C7eF57956486853E": {
@@ -184,8 +184,8 @@
     "asset": "0xdf0770dF86a8034b3EFEf0A1Bb3c889B8332FF56",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "b5b80abd-761c-4f1f-8513-17d53971cb95",
-    "apy-source": "defillama",
+    "apyId": "b5b80abd-761c-4f1f-8513-17d53971cb95",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0x37447E69A1Dd931a4B5b9c28C186B37e216aa4E8": {
@@ -193,8 +193,8 @@
     "asset": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     "name": "Idle",
     "description": "**Junior Tranche** - The vault supplies assets into a junior tranche of Idle. Junior tranches offer higher returns but with higher risk since they minize the risk of the corresponding.",
-    "apy-id": "4419943a-dc35-470c-8210-a6f087e1fb70",
-    "apy-source": "defillama",
+    "apyId": "4419943a-dc35-470c-8210-a6f087e1fb70",
+    "apySource": "defillama",
     "resolver": "idleJunior"
   },
   "0x89580C72a147A43CD05a9f001542729FdB194cFE": {
@@ -202,8 +202,8 @@
     "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "name": "Idle",
     "description": "**Junior Tranche** - The vault supplies assets into a junior tranche of Idle. Junior tranches offer higher returns but with higher risk since they minize the risk of the corresponding.",
-    "apy-id": "3cc9c2ca-40e6-48e1-ab59-56812f05343f",
-    "apy-source": "defillama",
+    "apyId": "3cc9c2ca-40e6-48e1-ab59-56812f05343f",
+    "apySource": "defillama",
     "resolver": "idleJunior"
   },
   "0x6Bd0C1823cd18f6bb8FFbb7Da0a3dEB09D2cFebB": {
@@ -211,8 +211,8 @@
     "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "name": "Idle",
     "description": "**Junior Tranche** - The vault supplies assets into a junior tranche of Idle. Junior tranches offer higher returns but with higher risk since they minize the risk of the corresponding.",
-    "apy-id": "25c15bbd-6287-4740-aca8-ff516327f5f3",
-    "apy-source": "defillama",
+    "apyId": "25c15bbd-6287-4740-aca8-ff516327f5f3",
+    "apySource": "defillama",
     "resolver": "idleJunior"
   },
   "0xBE1F69ed8f0cd5FCa72a28d8F249632e05Ec9655": {
@@ -220,8 +220,8 @@
     "asset": "0x971add32Ea87f10bD192671630be3BE8A11b8623",
     "name": "Yearn",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Yearn to maximize yield generation, leveraging Yearn's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "dcc0dac0-631e-4030-88a5-720e85e8e25a",
-    "apy-source": "defillama",
+    "apyId": "dcc0dac0-631e-4030-88a5-720e85e8e25a",
+    "apySource": "defillama",
     "resolver": "yearn"
   },
   "0x1061321151bD892F8044ecc095166a7F54D7d96a": {
@@ -229,8 +229,8 @@
     "asset": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     "name": "Yearn",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Yearn to maximize yield generation, leveraging Yearn's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "7be3388a-0591-4281-a6f3-eff3217693fa",
-    "apy-source": "defillama",
+    "apyId": "7be3388a-0591-4281-a6f3-eff3217693fa",
+    "apySource": "defillama",
     "resolver": "yearn"
   },
   "0x351DFF520260b118cA7830c32cD50158e2AF85Ef": {
@@ -238,8 +238,8 @@
     "asset": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
     "name": "Idle",
     "description": "**Senior Tranche** - The vault supplies assets into a senior tranche of Idle. Senior tranches offer stable returns with built-in coverage but reduced upside.",
-    "apy-id": "61f8ea49-8293-49f4-a959-84b0ef8872b5",
-    "apy-source": "defillama",
+    "apyId": "61f8ea49-8293-49f4-a959-84b0ef8872b5",
+    "apySource": "defillama",
     "resolver": "idleSenior"
   },
   "0xE4aa80152b36E0b52B366d8B1a5c8A36233DD978": {
@@ -247,8 +247,8 @@
     "asset": "0xBCe0Cf87F513102F22232436CCa2ca49e815C3aC",
     "name": "Pirex",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Pirex to maximize yield generation, leveraging Pirex's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "acee1e4d-a73c-4e20-98f7-e87c13d446e4",
-    "apy-source": "defillama",
+    "apyId": "acee1e4d-a73c-4e20-98f7-e87c13d446e4",
+    "apySource": "defillama",
     "resolver": "pirex"
   },
   "0xDD4D33dbB2A9922fB7524Ad5eD20b6F52EdA5d80": {
@@ -256,8 +256,8 @@
     "asset": "0x5a6A4D54456819380173272A5E8E9B9904BdF41B",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "e82428cd-c784-4b2a-b5cd-dc1bb3b4b845",
-    "apy-source": "defillama",
+    "apyId": "e82428cd-c784-4b2a-b5cd-dc1bb3b4b845",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0xE3267A9Ff2d38B748B6aA202e006F7d94Ca22df3": {
@@ -266,16 +266,16 @@
     "name": "Sommelier",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Sommelier to maximize yield generation, leveraging Sommelier's expertise across various protocols without needing personal management of the investment process.",
     "resolver": "sommelier",
-    "apy-id": "bc5d7692-fa5a-42aa-869f-42eb8c82b254",
-    "apy-source": "defillama"
+    "apyId": "bc5d7692-fa5a-42aa-869f-42eb8c82b254",
+    "apySource": "defillama"
   },
   "0xebEE0d3B137290438bd796109CB3e9eEa211d9D1": {
     "address": "0xebEE0d3B137290438bd796109CB3e9eEa211d9D1",
     "asset": "0x5a6A4D54456819380173272A5E8E9B9904BdF41B",
     "name": "Yearn",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Yearn to maximize yield generation, leveraging Yearn's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "092050e5-bf3c-48db-9b0f-d560fd0e932e",
-    "apy-source": "defillama",
+    "apyId": "092050e5-bf3c-48db-9b0f-d560fd0e932e",
+    "apySource": "defillama",
     "resolver": "yearn"
   },
   "0x27Da6422620A688619AaEf12BCc9C770C333A101": {
@@ -283,8 +283,8 @@
     "asset": "0xE7e2c68d3b13d905BBb636709cF4DfD21076b9D2",
     "name": "Aura",
     "description": "**Aura LP-Compounding** - This vault earns compounding interest on LP-tokens of the svETH / wstETH liquidity pool on Balancer. The LP-tokens are staked in a gauge on Aura to earn governance tokens. The rewards are then sold for additional LP tokens which get redeposited into the strategy.",
-    "apy-id": "45ec4aa9-c1db-46ce-ab74-9c78a2b17a48",
-    "apy-source": "defillama",
+    "apyId": "45ec4aa9-c1db-46ce-ab74-9c78a2b17a48",
+    "apySource": "defillama",
     "resolver": "aura"
   },
   "0xF6Fe643cb8DCc3E379Cdc6DB88818B09fdF2200d": {
@@ -293,16 +293,16 @@
     "name": "KelpDAO",
     "description": "**KelpDao Restaking** - This vault uses rsETH, a token representing a share of restaked Ethereum. Kelp DAO is developing this LRT on EigenLayer, aiming to provide liquidity and manage rewards for restaked Ethereum. Users benefit by saving on the effort typically required to select services and validators while maintaining the ability to leverage or exchange their rsETH for added flexibility.",
     "resolver": "kelpDao",
-    "apy-id": "33c732f6-a78d-41da-af5b-ccd9fa5e52d5",
-    "apy-source": "defillama"
+    "apyId": "33c732f6-a78d-41da-af5b-ccd9fa5e52d5",
+    "apySource": "defillama"
   },
   "0xdce45fEab60668195D891242914864837Aa22d8d": {
     "address": "0xdce45fEab60668195D891242914864837Aa22d8d",
     "asset": "0x625E92624Bc2D88619ACCc1788365A69767f6200",
     "name": "Curve",
     "description": "**Curve LP-Compounding** - This vault earns compounding interest on LP-tokens of the pyUSD / crvUSD liquidity pool on Curve. The LP-tokens are staked in a gauge on Curve to earn governance tokens. The rewards are then sold for additional LP tokens which get redeposited into the strategy.",
-    "apy-id": "93a073c9-0870-44a2-a5a6-d6091573be08",
-    "apy-source": "defillama",
+    "apyId": "93a073c9-0870-44a2-a5a6-d6091573be08",
+    "apySource": "defillama",
     "resolver": "curve"
   },
   "0xBD4458CfA154eA9ADE45BaF4dA6136cbC3A70f9f": {
@@ -311,8 +311,8 @@
     "name": "Origin",
     "description": "**Origin Restaking** - This vault uses PrimeETH, a token representing a share of restaked Ethereum. Origin is developing this LRT on EigenLayer, aiming to provide liquidity and manage rewards for restaked Ethereum. Users benefit by saving on the effort typically required to select services and validators while maintaining the ability to leverage or exchange their PrimeETH for added flexibility.",
     "resolver": "origin",
-    "apy-id": "124e5b78-1c7d-41f0-b4ed-5f422948344e",
-    "apy-source": "defillama"
+    "apyId": "124e5b78-1c7d-41f0-b4ed-5f422948344e",
+    "apySource": "defillama"
   },
   "0x24166a9C53D83b935c03F27C29081310d5bf1189": {
     "address": "0x24166a9C53D83b935c03F27C29081310d5bf1189",
@@ -320,16 +320,16 @@
     "name": "Aura",
     "description": "**Aura LP-Compounding** - This vault earns compounding interest on LP-tokens of the ezETH / WETH liquidity pool on Balancer. The LP-tokens are staked in a gauge on Aura to earn governance tokens. The rewards are then sold for additional LP tokens which get redeposited into the strategy.",
     "resolver": "aura",
-    "apy-id": "afce1731-b8d1-4410-9891-1c5cf8326ff1",
-    "apy-source": "defillama"
+    "apyId": "afce1731-b8d1-4410-9891-1c5cf8326ff1",
+    "apySource": "defillama"
   },
   "0xcA8A6287A69977022Ad3b5211d568192e131a574": {
     "address": "0xcA8A6287A69977022Ad3b5211d568192e131a574",
     "asset": "0x625E92624Bc2D88619ACCc1788365A69767f6200",
     "name": "Convex",
     "description": "**Convex LP-Compounding**  - This vault earns compounding interest on LP-tokens of the pyUSD / crvUSD liquidity pool on Curve. The LP-tokens are staked in a gauge on Convex to earn governance tokens. The rewards are then sold for additional LP tokens which get redeposited into the strategy.",
-    "apy-id": "443f0162-635e-493c-bc2b-4985f8f790e3",
-    "apy-source": "defillama",
+    "apyId": "443f0162-635e-493c-bc2b-4985f8f790e3",
+    "apySource": "defillama",
     "resolver": "convex"
   },
   "0x8dEbf3E349E799c10813CB94214d36a32E81906E": {
@@ -338,16 +338,16 @@
     "name": "Aura",
     "description": "**Aura LP-Compounding** - This vault earns compounding interest on LP-tokens of the svETH / wstETH liquidity pool on Balancer. The LP-tokens are staked in a gauge on Aura to earn governance tokens. The rewards are then sold for additional LP tokens which get redeposited into the strategy.",
     "resolver": "aura",
-    "apy-id": "d5461384-0367-4a2a-84db-0463596d3fcf",
-    "apy-source": "defillama"
+    "apyId": "d5461384-0367-4a2a-84db-0463596d3fcf",
+    "apySource": "defillama"
   },
   "0x0e67D694771260bD89AF0c4b788383c9B31c4dE1": {
     "address": "0x0e67D694771260bD89AF0c4b788383c9B31c4dE1",
     "asset": "0xdEdb11A6a23263469567C2881A9b9F8629eE0041",
     "name": "Aura",
     "description": "**Aura LP-Compounding** - This vault earns compounding interest on LP-tokens of the svETH / wstETH liquidity pool on Balancer. The LP-tokens are staked in a gauge on Aura to earn governance tokens. The rewards are then sold for additional LP tokens which get redeposited into the strategy.",
-    "apy-id": "d5461384-0367-4a2a-84db-0463596d3fcf",
-    "apy-source": "defillama",
+    "apyId": "d5461384-0367-4a2a-84db-0463596d3fcf",
+    "apySource": "defillama",
     "resolver": "aura"
   },
   "0x7bDd71e46D602916c065B027028Df686a27D5cB2": {
@@ -355,8 +355,8 @@
     "asset": "0x577A7f7EE659Aa14Dc16FD384B3F8078E23F1920",
     "name": "Aura",
     "description": "**Aura LP-Compounding** - This vault earns compounding interest on LP-tokens of the VCX / WETH liquidity pool on Balancer. The LP-tokens are staked in a gauge on Aura to earn governance tokens. The rewards are then sold for additional LP tokens which get redeposited into the strategy.",
-    "apy-id": "0a7a5fae-72a7-4ebb-80c6-fbe73d3f93ac",
-    "apy-source": "defillama",
+    "apyId": "0a7a5fae-72a7-4ebb-80c6-fbe73d3f93ac",
+    "apySource": "defillama",
     "resolver": "aura"
   },
   "0x9E0c5d524dc3Ff0aa734c52aa57ab623436364e6": {
@@ -365,8 +365,8 @@
     "name": "Ion",
     "description": "**Points Lending** - This vault uses a lending strategy on ION using the weETH market. Which generates compound interest on your wstETH by lending it out to borrowers. This strategy also earns points for ION and EtherFi.",
     "resolver": "ion",
-    "apy-id": "a7c29d5b-da25-4329-a98e-ca427c075d23",
-    "apy-source": "defillama"
+    "apyId": "a7c29d5b-da25-4329-a98e-ca427c075d23",
+    "apySource": "defillama"
   },
   "0xA84397004Abe8229CC481cE91BA850ECd8204822": {
     "address": "0xA84397004Abe8229CC481cE91BA850ECd8204822",
@@ -374,7 +374,7 @@
     "name": "Ion",
     "description": "**Points Lending** - This vault uses a lending strategy on ION using the weETH market. Which generates compound interest on your wstETH by lending it out to borrowers. This strategy also earns points for ION and Kelp DAO.",
     "resolver": "ion",
-    "apy-id": "e05cc083-3ce9-47f3-87c7-c7cba4c9a8c6",
-    "apy-source": "defillama"
+    "apyId": "e05cc083-3ce9-47f3-87c7-c7cba4c9a8c6",
+    "apySource": "defillama"
   }
 }

--- a/archive/descriptions/strategies/10.json
+++ b/archive/descriptions/strategies/10.json
@@ -4,8 +4,8 @@
     "asset": "0x6C5019D345Ec05004A7E7B0623A91a0D9B8D590d",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "c5c35ec1-056e-42cc-a276-97da9b813cb3",
-    "apy-source": "defillama",
+    "apyId": "c5c35ec1-056e-42cc-a276-97da9b813cb3",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0x49DE4F723F73eFE3cAe048b9a5CA061c13aF65dB": {
@@ -13,8 +13,8 @@
     "asset": "0x22D63A26c730d49e5Eab461E4f5De1D8BdF89C92",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "a83ea746-1cc2-44ef-ab91-3fc0459ff6d1",
-    "apy-source": "defillama",
+    "apyId": "a83ea746-1cc2-44ef-ab91-3fc0459ff6d1",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0x066f92a0e668e6FC497Ae53576E74d1f77820004": {
@@ -22,8 +22,8 @@
     "asset": "0xF753A50fc755c6622BBCAa0f59F0522f264F006e",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "c8ad893a-4d4b-474c-a7dc-529663a06925",
-    "apy-source": "defillama",
+    "apyId": "c8ad893a-4d4b-474c-a7dc-529663a06925",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0x93e944D7F37Ab622fC4911Cf42c529424a009d3B": {
@@ -31,8 +31,8 @@
     "asset": "0x207AddB05C548F262219f6bFC6e11c02d0f7fDbe",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "a3fbc2ff-8e82-4caa-99bc-06752279ecc2",
-    "apy-source": "defillama",
+    "apyId": "a3fbc2ff-8e82-4caa-99bc-06752279ecc2",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0xD2A73D2045706CF1250aBa3e6b42D8c07ae4eA14": {
@@ -40,8 +40,8 @@
     "asset": "0x0df083de449F75691fc5A36477a6f3284C269108",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "b4d2f975-2beb-47c6-ada2-8d8eeb605f56",
-    "apy-source": "defillama",
+    "apyId": "b4d2f975-2beb-47c6-ada2-8d8eeb605f56",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0x912c7945D83C34249B4D211421bD24b6F17fb3E4": {
@@ -49,8 +49,8 @@
     "asset": "0x7178F61694ba9109205B8d6F686282307625e62D",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "e34fddd6-f2d8-4f38-a11d-fa31aa3a63e9",
-    "apy-source": "defillama",
+    "apyId": "e34fddd6-f2d8-4f38-a11d-fa31aa3a63e9",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0x76133E7EADEcC50Cd4C226C2274B51635491E0fa": {
@@ -58,8 +58,8 @@
     "asset": "0xB720FBC32d60BB6dcc955Be86b98D8fD3c4bA645",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "614c95f5-e123-4be1-92b6-2656e1ac5cb7",
-    "apy-source": "defillama",
+    "apyId": "614c95f5-e123-4be1-92b6-2656e1ac5cb7",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0xa511A6E551B56726a5DE024E67EEDFAA40949007": {
@@ -67,8 +67,8 @@
     "asset": "0x6dA98Bde0068d10DDD11b468b197eA97D96F96Bc",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "bacf925e-28ff-4967-b853-e98d3d5842a1",
-    "apy-source": "defillama",
+    "apyId": "bacf925e-28ff-4967-b853-e98d3d5842a1",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0xCd55C34bc488fFa41Ab8e42AE590926b6955b0cF": {
@@ -76,8 +76,8 @@
     "asset": "0x8134A2fDC127549480865fB8E5A9E8A8a95a54c5",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "0ea4805a-ed01-40c7-8b33-976967822bc1",
-    "apy-source": "defillama",
+    "apyId": "0ea4805a-ed01-40c7-8b33-976967822bc1",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0xb74De14C51B1bCD60525A5f44016c67865AA1a6D": {
@@ -85,8 +85,8 @@
     "asset": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
     "name": "Idle",
     "description": "**Senior Tranche** - The vault supplies assets into a senior tranche of Idle. Senior tranches offer stable returns with built-in coverage but reduced upside.",
-    "apy-id": "505fa2c9-f1f5-485f-b416-ed27bc34a558",
-    "apy-source": "defillama",
+    "apyId": "505fa2c9-f1f5-485f-b416-ed27bc34a558",
+    "apySource": "defillama",
     "resolver": "idleSenior"
   },
   "0x0D8C42319Cf265FBEfa7a5bcCbbd5Cb702c7E990": {
@@ -94,8 +94,8 @@
     "asset": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
     "name": "Idle",
     "description": "**Junior Tranche** - The vault supplies assets into a junior tranche of Idle. Junior tranches offer higher returns but with higher risk since they minize the risk of the corresponding.",
-    "apy-id": "324f5064-a293-4426-a582-2bd3d408f401",
-    "apy-source": "defillama",
+    "apyId": "324f5064-a293-4426-a582-2bd3d408f401",
+    "apySource": "defillama",
     "resolver": "idleJunior"
   },
   "0xe2839976C6c85b049Ba1DFBA7b837E8B36aC1848": {
@@ -103,8 +103,8 @@
     "asset": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
     "name": "Idle",
     "description": "**Junior Tranche** - The vault supplies assets into a junior tranche of Idle. Junior tranches offer higher returns but with higher risk since they minize the risk of the corresponding.",
-    "apy-id": "5919ed4b-d459-47a2-9ad5-40c67a787790",
-    "apy-source": "defillama",
+    "apyId": "5919ed4b-d459-47a2-9ad5-40c67a787790",
+    "apySource": "defillama",
     "resolver": "idleJunior"
   },
   "0x4a71a7CB0D710F03BE90F4276bf996271706C816": {
@@ -112,8 +112,8 @@
     "asset": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
     "name": "Idle",
     "description": "**Senior Tranche** - The vault supplies assets into a senior tranche of Idle. Senior tranches offer stable returns with built-in coverage but reduced upside.",
-    "apy-id": "22de3492-71c1-4a00-b3cc-453fbbe1701c",
-    "apy-source": "defillama",
+    "apyId": "22de3492-71c1-4a00-b3cc-453fbbe1701c",
+    "apySource": "defillama",
     "resolver": "idleSenior"
   },
   "0xd11A312a7d9745C62dfc014D72E7Bb2403DABf72": {
@@ -121,8 +121,8 @@
     "asset": "0x0df083de449F75691fc5A36477a6f3284C269108",
     "name": "Velodrome",
     "description": "**Velodrome LP-Compounding** - This vault earns compounding interest on LP-tokens of the OP / USDC liquidity pool on Velodrome. The LP-tokens are staked in a gauge on Velodrome to earn governance tokens. The rewards are then sold for additional LP tokens which get redeposited into the strategy.",
-    "apy-id": "48fcc31e-1e01-4ab9-9ea7-6b39e5a0cfb8",
-    "apy-source": "defillama",
+    "apyId": "48fcc31e-1e01-4ab9-9ea7-6b39e5a0cfb8",
+    "apySource": "defillama",
     "resolver": "velodrome"
   },
   "0x4c95761fA7Ee62c1023097b531a8B8E14F486956": {
@@ -131,7 +131,7 @@
     "name": "AaveV3",
     "description": "**Lending** - This vault uses a lending strategy on AaveV3 using the WBTC market. Which generates compound interest on your WBTC by lending it out to borrowers.",
     "resolver": "aaveV3",
-    "apy-id": "e053590b-54f1-40aa-ae0d-14e701ca734c",
-    "apy-source": "defillama"
+    "apyId": "e053590b-54f1-40aa-ae0d-14e701ca734c",
+    "apySource": "defillama"
   }
 }

--- a/archive/descriptions/strategies/137.json
+++ b/archive/descriptions/strategies/137.json
@@ -4,8 +4,8 @@
     "asset": "0x29e38769f23701A2e4A8Ef0492e19dA4604Be62c",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "74a9a7da-4506-41ed-af08-08043903a99d",
-    "apy-source": "defillama",
+    "apyId": "74a9a7da-4506-41ed-af08-08043903a99d",
+    "apySource": "defillama",
     "resolver": "beefy"
   },
   "0xdd1AB4f32a68eCA535a07bdFDfB350D29cC59230": {
@@ -13,8 +13,8 @@
     "asset": "0x1205f31718499dBf1fCa446663B532Ef87481fe1",
     "name": "Beefy",
     "description": "**Automated Asset Strategy** - This vault deploys your assets into automated asset strategies of Beefy to maximize yield generation, leveraging Beefy's expertise across various protocols without needing personal management of the investment process.",
-    "apy-id": "ecafefda-2c8b-43be-a40a-a8f119f56cf8",
-    "apy-source": "defillama",
+    "apyId": "ecafefda-2c8b-43be-a40a-a8f119f56cf8",
+    "apySource": "defillama",
     "resolver": "beefy"
   }
 }

--- a/archive/descriptions/strategies/42161.json
+++ b/archive/descriptions/strategies/42161.json
@@ -4,8 +4,8 @@
     "asset": "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
     "name": "FraxLend",
     "description": "**Lending** - This vault uses a lending strategy on FraxLend using the FRAX market. Which generates compound interest on your FRAX by lending it out to borrowers.",
-    "apy-id": "",
-    "apy-source": "custom",
+    "apyId": "",
+    "apySource": "custom",
     "resolver": "none"
   },
   "0x9168AC3a83A31bd85c93F4429a84c05db2CaEF08": {
@@ -13,8 +13,8 @@
     "asset": "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
     "name": "FraxLend",
     "description": "**Lending** - This vault uses a lending strategy on FraxLend using the FRAX market. Which generates compound interest on your FRAX by lending it out to borrowers.",
-    "apy-id": "",
-    "apy-source": "custom",
+    "apyId": "",
+    "apySource": "custom",
     "resolver": "none"
   },
   "0x6076ebDFE17555ed3E6869CF9C373Bbd9aD55d38": {
@@ -22,8 +22,8 @@
     "asset": "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
     "name": "FraxLend",
     "description": "**Lending** - This vault uses a lending strategy on FraxLend using the FRAX market. Which generates compound interest on your FRAX by lending it out to borrowers.",
-    "apy-id": "",
-    "apy-source": "custom",
+    "apyId": "",
+    "apySource": "custom",
     "resolver": "none"
   },
   "0x61dCd1Da725c0Cdb2C6e67a0058E317cA819Cf5f": {
@@ -31,8 +31,8 @@
     "asset": "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
     "name": "AaveV3",
     "description": "**Lending** - This vault uses a lending strategy on AaveV3 using the FRAX market. Which generates compound interest on your FRAX by lending it out to borrowers.",
-    "apy-id": "8d4d3acb-e1bf-471a-8256-36b90a8f4d25",
-    "apy-source": "defillama",
+    "apyId": "8d4d3acb-e1bf-471a-8256-36b90a8f4d25",
+    "apySource": "defillama",
     "resolver": "aaveV3"
   },
   "0x323053A0902E67791c06F65A5D2097ee79dD740F": {
@@ -40,8 +40,8 @@
     "asset": "0x17FC002b466eEc40DaE837Fc4bE5c67993ddBd6F",
     "name": "CurveGauge",
     "description": "**Curve LP-Compounding** - This vault single side deposits FRAX into the crvUSD / FRAX liquidity pool on Curve. It earns compounding interest on LP-tokens of the by staking in a gauge on Curve to earn governance tokens. The rewards are then sold for additional LP tokens which get redeposited into the strategy.",
-    "apy-id": "",
-    "apy-source": "custom",
+    "apyId": "",
+    "apySource": "custom",
     "resolver": "curve"
   },
   "0x8904c44f1b2AD67a1c8Ac43D6774272Cd5836eaA": {
@@ -50,7 +50,7 @@
     "name": "AaveV3",
     "description": "**Lending** - This vault uses a lending strategy on AaveV3 using the WBTC market. Which generates compound interest on your WBTC by lending it out to borrowers.",
     "resolver": "aaveV3",
-    "apy-id": "7c5e69a4-2430-4fa2-b7cb-857f79d7d1bf",
-    "apy-source": "defillama"
+    "apyId": "7c5e69a4-2430-4fa2-b7cb-857f79d7d1bf",
+    "apySource": "defillama"
   }
 }


### PR DESCRIPTION
makes consuming the values through JSON easier.

E.g. with old syntax you need to do:
`data["apy-id"]` to retrieve the value.

new syntax:
`data.apyId`